### PR TITLE
fix: safe lines after saving

### DIFF
--- a/addons/gdscript_formatter/gdscript_formatter.gd
+++ b/addons/gdscript_formatter/gdscript_formatter.gd
@@ -259,6 +259,7 @@ func _reload_code_edit(code_edit: CodeEdit, new_text: String, tag_saved: bool = 
 	code_edit.text = new_text
 	if tag_saved:
 		code_edit.tag_saved_version()
+		code_edit.text_changed.emit()
 
 	var new_text_line_count := code_edit.get_line_count()
 	# Breakpoints


### PR DESCRIPTION
When saving the script, there is a high probability that the safe lines will not refresh.

After emitting the signal "text_changed", it's resolved.
![image](https://github.com/user-attachments/assets/e2a1d002-2272-4fc7-8c6e-5a8706e3f6b2)
