### PR TITLE
[Fix] _get_settings() return 175 as default value

### DIFF
--- a/addons/gdscript_formatter/gdscript_formatter.gd
+++ b/addons/gdscript_formatter/gdscript_formatter.gd
@@ -453,9 +453,8 @@ func _get_setting(key: String) -> Variant:
 	if settings.get(_SETTING_CUSTOM_SETTINGS_ENABLED):
 		return settings.get(key)
 	var editor_settings := get_editor_interface().get_editor_settings()
-	if editor_settings.has_setting(key):
-		return editor_settings.get_setting(key)
-	return 175
+	assert(editor_settings.has_setting(key), "Setting " + key + " is missing")
+	return editor_settings.get_setting(key)
 
 
 func _format_code(script_path: String, code: String, formated: Array) -> bool:


### PR DESCRIPTION
Additional fix on issue #13
If different settings could store different value types and the setting with a particular key was not found, it's preferable to throw an error rather than assign it some default value